### PR TITLE
Faster and more semantically correct aliasing of on/un

### DIFF
--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -15,19 +15,13 @@ has _listeners => (
     default => sub { {} },
 );
 
-sub on {
-    goto &subscribe;
-}
-
 sub subscribe {
     my ( $self, $name, $sub ) = @_;
     push @{ $self->_listeners->{$name} }, $sub;
     return;
 }
 
-sub un {
-    goto &unsubscribe;
-}
+*on = \&subscribe;
 
 sub unsubscribe {
     my ( $self, $name, $sub ) = @_;
@@ -45,6 +39,8 @@ sub unsubscribe {
     }
     return;
 }
+
+*un = \&unsubscribe;
 
 sub emit {
     my ( $self, $name, %args ) = @_;


### PR DESCRIPTION
Faster and more semantically correct aliasing of on/un.

While `goto &sub` is fun, it adds one more layer of indirection. Unless you need to choose what method to delegate to at runtime, a direct (typeglob) alias should be faster.
