### PR TITLE
'subscribe' returns a coderef that, when invoked, unsubscribe

### DIFF
--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -24,12 +24,27 @@ Subscribe to an event from this object. C<event_name> is the name of the event.
 C<subref> is a subroutine reference that will get either a L<Beam::Event> object
 (if using the L<emit> method) or something else (if using the L<emit_args> method).
 
+Return a coderef that, when called, unsubscribe the current subref.
+
+    my $unsubscribe = $emitter->subscribe( open_door => sub {
+        warn "ding!";
+    } );
+
+    $emitter->emit( 'open_door' );  # ding!
+
+    $unsubscribe->();
+
+    $emitter->emit( 'open_door' );  # no ding
+
+
 =cut
 
 sub subscribe {
     my ( $self, $name, $sub ) = @_;
     push @{ $self->_listeners->{$name} }, $sub;
-    return;
+    return sub { 
+        $self->unsubscribe($name => $sub);
+    };
 }
 
 =method on ( event_name, subref )

--- a/t/unsubscribe.t
+++ b/t/unsubscribe.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+
+use Beam::Emitter;
+
+{
+    package MyEmitter;
+
+    use Moose; with 'Beam::Emitter';
+
+}
+
+my $emitter = MyEmitter->new;
+
+my $counter = 0;
+
+my $unsubscribe = $emitter->on( ping => sub { $counter++ } );
+
+is $counter => 0, 'counter at 0';
+
+$emitter->emit('ping');
+
+is $counter => 1, 'counter hit';
+
+$unsubscribe->();
+
+$emitter->emit('ping');
+
+is $counter => 1, 'no hit, unsubscribed';
+
+
+
+
+

--- a/t/unsubscribe.t
+++ b/t/unsubscribe.t
@@ -8,8 +8,7 @@ use Beam::Emitter;
 {
     package MyEmitter;
 
-    use Moose; with 'Beam::Emitter';
-
+    use Moo; with 'Beam::Emitter';
 }
 
 my $emitter = MyEmitter->new;


### PR DESCRIPTION
A little sugar, allowing for (I think) the more convenient

```
my $unsub = $emitter->on( 'foo' => sub { ... } );

...

$unsub->();
```

over

```
$emitter->on( 'foo' => my $sub = sub { ... } );

...

$emitter->unsubscribe('foo' => $sub);
```