### PR TITLE
allow to subscribe to all events via '*'

### DIFF
--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -24,6 +24,8 @@ Subscribe to an event from this object. C<event_name> is the name of the event.
 C<subref> is a subroutine reference that will get either a L<Beam::Event> object
 (if using the L<emit> method) or something else (if using the L<emit_args> method).
 
+If the event name is C<*>, the subref will be called on all events.
+
 =cut
 
 sub subscribe {
@@ -88,7 +90,7 @@ sub emit {
     $args{ emitter  } = $self;
     $args{ name     } = $name;
     my $event = $class->new( %args );
-    for my $listener ( @{ $self->_listeners->{$name} } ) {
+    for my $listener ( map { @{ $self->_listeners->{$_} } } $name, '*' ) {
         $listener->( $event );
         last if $event->is_stopped;
     }

--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -90,7 +90,7 @@ sub emit {
     $args{ emitter  } = $self;
     $args{ name     } = $name;
     my $event = $class->new( %args );
-    for my $listener ( map { @{ $self->_listeners->{$_} } } $name, '*' ) {
+    for my $listener ( map { @{ $self->_listeners->{$_} || [] } } $name, '*' ) {
         $listener->( $event );
         last if $event->is_stopped;
     }

--- a/t/subscribe-to-all.t
+++ b/t/subscribe-to-all.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+{
+    package MyEmitter;
+    use Moose; with 'Beam::Emitter';
+}
+
+my $emitter = MyEmitter->new;
+
+$emitter->on( 'foo', sub { pass "foo" } );
+$emitter->on( '*',   sub { pass "*" } );
+
+$emitter->emit( 'foo' );
+
+
+
+


### PR DESCRIPTION
Can be useful to either catch all events,
or implement more complex event matching.
E.g.

```
    $emitter->on('*' => sub {
            my $event = shift;
            next unless $event->name =~ /^foo_/;

            ...
    });
```
