### PR TITLE
secure the unsubscribe callback against the emitter object being destroyed early

### DIFF
--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -69,7 +69,8 @@ sub subscribe {
     weaken $self;
     weaken $sub;
     return sub {
-        $self->unsubscribe($name => $sub);
+        $self->unsubscribe($name => $sub)
+	  if defined $self;
     };
 }
 

--- a/t/unsubscribe_global_destruction.t
+++ b/t/unsubscribe_global_destruction.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+
+use Test::Exception tests => 1;
+
+use Beam::Emitter;
+
+{
+    package MyEmitter;
+
+    use Moo; with 'Beam::Emitter';
+}
+
+my $emitter = MyEmitter->new;
+
+my $unsubscribe = $emitter->on( ping => sub { } );
+
+# simulate Global Destruction with $emitter destroyed first
+
+undef $emitter;
+
+lives_ok { $unsubscribe->() } 'unsubscribe survived destroyed emitter';
+
+
+
+
+
+


### PR DESCRIPTION
If the emitter object is destroyed prior to the invocation of an
unsubscribe callback, Perl will either throw an exception during
normal execution

  Can't call method "unsubscribe" on an undefined value at
  lib/Beam/Emitter.pm line 72

or will generate an error message during global cleanup

  (in cleanup) Can't call method "unsubscribe" on an undefined
      value at lib/Beam/Emitter.pm line 72

The problem mostly arises in global destruction, when the emitter
object may be destroyed prior to the listener.  Here's an example:

```
  #! /usr/bin/env perl

  use 5.10.0;
  use strict;
  use warnings;

  package Foo {
      use Moo;
      with 'Beam::Emitter';
  }

  package Bar {

      use Devel::GlobalDestruction;

      use Moo;
      has cb => ( is => 'rw' );

      sub DEMOLISH {

	  my $self = shift;
	  return if in_global_destruction;
	  $self->cb->();
      }
  }

  my $f = Foo->new;
  my $b = Bar->new;
  $b->cb( $f->subscribe( 'stuff', sub { say "got stuff" } ) );

  undef $f;
```

Note that DEMOLISH attempts to avoid invoking the callback, but to no avail.