### PR TITLE
one-shot listeners corrupted the list of listeners

### DIFF
--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -129,7 +129,12 @@ sub emit {
     $args{ emitter  } = $self;
     $args{ name     } = $name;
     my $event = $class->new( %args );
-    for my $listener ( @{ $self->_listeners->{$name} } ) {
+
+    # don't use $self->_listeners->{$name} directly, as callbacks may unsubscribe
+    # from $name, changing the array, and confusing the for loop
+    my @listeners = @{ $self->_listeners->{$name} };
+
+    for my $listener ( @listeners  ) {
         $listener->( $event );
         last if $event->is_stopped;
     }
@@ -148,7 +153,12 @@ features like L<stop|Beam::Event/stop> and L<stop default|Beam::Event/stop_defau
 
 sub emit_args {
     my ( $self, $name, @args ) = @_;
-    for my $listener( @{ $self->_listeners->{$name} } ) {
+
+    # don't use $self->_listeners->{$name} directly, as callbacks may unsubscribe
+    # from $name, changing the array, and confusing the for loop
+    my @listeners = @{ $self->_listeners->{$name} };
+
+    for my $listener( @listeners ) {
         $listener->( @args );
     }
     return;

--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -125,6 +125,9 @@ Use the C<class> key in C<event_args> to specify a different Event class.
 
 sub emit {
     my ( $self, $name, %args ) = @_;
+
+    return unless exists $self->_listeners->{$name};
+
     my $class = delete $args{ class } || "Beam::Event";
     $args{ emitter  } = $self;
     $args{ name     } = $name;
@@ -154,11 +157,13 @@ features like L<stop|Beam::Event/stop> and L<stop default|Beam::Event/stop_defau
 sub emit_args {
     my ( $self, $name, @args ) = @_;
 
+    return unless exists $self->_listeners->{$name};
+
     # don't use $self->_listeners->{$name} directly, as callbacks may unsubscribe
     # from $name, changing the array, and confusing the for loop
     my @listeners = @{ $self->_listeners->{$name} };
 
-    for my $listener( @listeners ) {
+    for my $listener ( @listeners ) {
         $listener->( @args );
     }
     return;

--- a/t/emitter.t
+++ b/t/emitter.t
@@ -129,4 +129,11 @@ subtest 'emit args' => sub {
     $emitter->foo;
 };
 
+subtest 'no listeners' => sub {
+    my $emitter = My::Emitter::Args->new;
+
+    lives_ok { $emitter->emit( 'foo' ) } "emit";
+    lives_ok { $emitter->emit_args( 'foo' ) } "emit_args";
+};
+
 done_testing;

--- a/t/one-shot.t
+++ b/t/one-shot.t
@@ -1,0 +1,62 @@
+#! perl
+
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package Foo;
+    use Moo;
+    with 'Beam::Emitter';
+}
+
+subtest "emit" => sub {
+    my $foo = Foo->new;
+
+    my @detached = ();
+
+    my ( $us1, $us2 );
+    $us1 = $foo->subscribe(
+        detach => sub {
+            push @detached, 1;
+            $us1->();
+        } );
+
+    $us2 = $foo->subscribe(
+        detach => sub {
+            push @detached, 2;
+            $us2->();
+        } );
+
+    $foo->emit( 'detach' );
+
+    is_deeply( [ sort @detached ], [ 1, 2 ], "detached both objects" );
+
+  };
+
+subtest "emit_args" => sub {
+    my $foo = Foo->new;
+
+    my @detached = ();
+
+    my ( $us1, $us2 );
+    $us1 = $foo->subscribe(
+        detach => sub {
+            push @detached, 1;
+            $us1->();
+        } );
+
+    $us2 = $foo->subscribe(
+        detach => sub {
+            push @detached, 2;
+            $us2->();
+        } );
+
+    $foo->emit_args( 'detach' );
+
+    is_deeply( [ sort @detached ], [ 1, 2 ], "detached both objects" );
+
+  };
+
+
+done_testing;


### PR DESCRIPTION
iterating over the actual list of listeners is problematic, as
a one-shot listener will remove itself from the list, which
confuses foreach.