### PR TITLE
Provide the ability to store more information about listeners in the emitter object

### DIFF
--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -209,8 +209,8 @@ sub emit_args {
 
 =method listeners ( event_name )
 
-Returns an array containing the listeners which have subscribed to the
-specified event from this emitter.  The array elements are either
+Returns a list containing the listeners which have subscribed to the
+specified event from this emitter.  The list elements are either
 instances of L<Beam::Listener> or of custom classes specified in calls
 to L</subscribe>.
 
@@ -220,7 +220,7 @@ sub listeners {
 
     my ( $self, $name ) = @_;
 
-    return $self->_listeners->{$name} || [];
+    return @{ $self->_listeners->{$name} || [] };
 }
 
 1;

--- a/lib/Beam/Listener.pm
+++ b/lib/Beam/Listener.pm
@@ -1,0 +1,62 @@
+package Beam::Listener;
+our $VERSION = '1.004';
+
+use strict;
+use warnings;
+
+use Types::Standard qw(:all);
+use Moo;
+
+=attr code
+
+A coderef which will be invoked when the event is distributed.
+
+=cut
+
+has callback => (
+    is  => 'ro',
+    isa => CodeRef,
+    required => 1,
+);
+
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+  package MyListener;
+
+  extends 'Beam::Listener';
+
+
+  # add metadata with subscription time
+  has sub_time => is ( 'ro',
+                        init_arg => undef,
+                        default => sub { time() },
+  );
+
+   # My::Emitter consumes the Beam::Emitter role
+   my $emitter = My::Emitter->new;
+   $emitter->on( "foo", sub {
+        my ( $event ) = @_;
+        print "Foo happened!\n";
+        # stop this event from continuing
+        $event->stop;
+    },
+    class => MyListener
+    );
+
+
+=head1 DESCRIPTION
+
+This is the base class used by C<Beam::Emitter> objects to store information
+about listeners. Create a subclass to add data attributes.
+
+=head1 SEE ALSO
+
+=over 4
+
+=item L<Beam::Emitter>
+
+=back

--- a/t/listeners.t
+++ b/t/listeners.t
@@ -48,19 +48,19 @@ my $us22 = $foo->subscribe( evt2 => $s22, class => 'Goo', attr => 's22' );
 
 {
     my @s = sort byref $s11, $s12;
-    my @cb = sort byref map { $_->callback } @{ $foo->listeners( 'evt1' ) };
+    my @cb = sort byref map { $_->callback } $foo->listeners( 'evt1' );
     is_deeply( \@cb, \@s, 'initial evt1 listeners' );
 }
 
 {
     my @s = sort byref $s21, $s22;
-    my @cb = sort byref map { $_->callback } @{ $foo->listeners( 'evt2' ) };
+    my @cb = sort byref map { $_->callback } $foo->listeners( 'evt2' );
     is_deeply( \@cb, \@s, 'initial evt2 listeners' );
 }
 
 {
     &$us12;
-    my @l  = sort byref @{ $foo->listeners( 'evt1' ) };
+    my @l  = sort byref $foo->listeners( 'evt1' );
     my @cb = map { $_->callback } @l;
     is_deeply( \@cb,  [ $s11 ], 'after evt1 listener removal' );
     ok( $l[0]->isa( 'Beam::Listener' ) && ! $l[0]->isa( 'Goo' ), 'default Listener class' );
@@ -68,7 +68,7 @@ my $us22 = $foo->subscribe( evt2 => $s22, class => 'Goo', attr => 's22' );
 
 {
     &$us21;
-    my @l  = sort byref @{ $foo->listeners( 'evt2' ) };
+    my @l  = sort byref $foo->listeners( 'evt2' );
     my @cb = map { $_->callback } @l;
     is_deeply( \@cb,  [ $s22 ], 'after evt2 listener removal' );
     ok( $l[0]->isa( 'Goo' ), 'custom Listener class' );

--- a/t/listeners.t
+++ b/t/listeners.t
@@ -1,0 +1,78 @@
+#! perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+use Scalar::Util qw[ refaddr ];
+
+{
+    package Foo;
+    use Moo;
+    with 'Beam::Emitter';
+}
+
+{
+    package Goo;
+    use Moo;
+    extends 'Beam::Listener';
+
+    has attr => ( is => 'ro', required => 1 );
+
+}
+
+sub byref { refaddr $a <= refaddr $b }
+
+my $foo = Foo->new;
+
+my $s11 = sub { 'evt11' };
+my $s12 = sub { 'evt12' };
+my $s21 = sub { 'evt21' };
+my $s22 = sub { 'evt22' };
+
+my $us11 = $foo->subscribe( evt1 => $s11 );
+my $us12 = $foo->subscribe( evt1 => $s12 );
+my $us21 = $foo->subscribe( evt2 => $s21 );
+
+# try an alternate listener class.
+
+# test constructor is being called with args
+throws_ok(
+    sub { $foo->subscribe( evt2 => $s22, class => 'Goo' ) },
+    qr/missing required arguments/i,
+    "missing attr for custom listener class"
+);
+
+my $us22 = $foo->subscribe( evt2 => $s22, class => 'Goo', attr => 's22' );
+
+{
+    my @s = sort byref $s11, $s12;
+    my @cb = sort byref map { $_->callback } @{ $foo->listeners( 'evt1' ) };
+    is_deeply( \@cb, \@s, 'initial evt1 listeners' );
+}
+
+{
+    my @s = sort byref $s21, $s22;
+    my @cb = sort byref map { $_->callback } @{ $foo->listeners( 'evt2' ) };
+    is_deeply( \@cb, \@s, 'initial evt2 listeners' );
+}
+
+{
+    &$us12;
+    my @l  = sort byref @{ $foo->listeners( 'evt1' ) };
+    my @cb = map { $_->callback } @l;
+    is_deeply( \@cb,  [ $s11 ], 'after evt1 listener removal' );
+    ok( $l[0]->isa( 'Beam::Listener' ) && ! $l[0]->isa( 'Goo' ), 'default Listener class' );
+}
+
+{
+    &$us21;
+    my @l  = sort byref @{ $foo->listeners( 'evt2' ) };
+    my @cb = map { $_->callback } @l;
+    is_deeply( \@cb,  [ $s22 ], 'after evt2 listener removal' );
+    ok( $l[0]->isa( 'Goo' ), 'custom Listener class' );
+}
+
+
+done_testing;


### PR DESCRIPTION
In my application emitters require more information about listeners than just the callback coderef.
The background for this is that I'm implementing one-to-one sending of events in addition to the existing one-to-many distribution, and the emitter needs to know which callback to invoke for a given subscriber.  

This changeset provides a general interface to attaching extra data for each listener in the cache.
I've introduced a `Beam::Listener` class which `subscribe()` inserts into the `listener` attribute.  I've copied the interface provided by `emit()` to allow the caller to use a child class of `Beam::Listener` as well as extra attributes.

In order that the emitter have access to this, I've renamed `_listener` to `listener` and thus made it part of the public API.

I've not yet written tests, so this PR is not yet ready, but I'd like to know if this approach is something you'd incorporate.