### PR TITLE
use Test::API to ensure namespace is clean

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -12,6 +12,7 @@ on 'test' => sub {
   requires "IPC::Open3" => "0";
   requires "Test::Exception" => "0";
   requires "Test::More" => "0";
+  requires "Test::API" => "0";
 };
 
 on 'test' => sub {

--- a/dist.ini
+++ b/dist.ini
@@ -130,6 +130,7 @@ Types::Standard = 0.008 ; First version with ConsumerOf
 [Prereqs / TestRequires]
 Test::More = 0
 Test::Fatal = 0
+Test::API = 0
 
 [Prereqs / TestRecommends]
 Test::LeakTrace = 0

--- a/t/namespace-clean.t
+++ b/t/namespace-clean.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Fatal;
+use Test::API;
 
 {
     package My::Emitter;
@@ -10,16 +10,25 @@ use Test::Fatal;
     with 'Beam::Emitter';
 }
 
-my @methods = qw(
-    HashRef
-    weaken refaddr
-    croak
+class_api_ok(
+    'My::Emitter',
+    qw[
+      DOES
+      after
+      around
+      before
+      emit
+      emit_args
+      extends
+      has
+      listeners
+      new
+      on
+      subscribe
+      un
+      unsubscribe
+      with
+      ]
 );
-
-for my $method ( @methods ) {
-    like exception { My::Emitter->new->$method },
-        qr/Can't locate object method "$method" via package "My::Emitter"/,
-        $method . ' cleaned up and not available on our composed class';
-}
 
 done_testing;


### PR DESCRIPTION
Test::API  ensures that only the methods you list are exported, so there's no possibility of a false negative.