### PR TITLE
allow emitter attribute to be specified for Event object created by emit()

### DIFF
--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -167,7 +167,7 @@ sub emit {
     return unless exists $self->_listeners->{$name};
 
     my $class = delete $args{ class } || "Beam::Event";
-    $args{ emitter  } = $self;
+    $args{ emitter  } ||= $self;
     $args{ name     } ||= $name;
     my $event = $class->new( %args );
 

--- a/t/emitter.t
+++ b/t/emitter.t
@@ -4,6 +4,8 @@ use warnings;
 use Test::More;
 use Test::Fatal;
 
+use Scalar::Util qw[ refaddr ];
+
 {
     package My::Emitter;
 
@@ -143,6 +145,19 @@ subtest 'custom name' => sub {
     $emitter->emit( 'foo', name => 'bar' );
     is scalar @events, 1, 'foo event caught';
     is $events[0]->name, 'bar', 'foo event correctly renamed bar';
+};
+
+
+subtest 'alternate emitter' => sub {
+
+    my $emitter = My::Emitter->new;
+    my $alt_emitter = My::Emitter->new;
+    my @events;
+    $emitter->on( 'foo', sub { push @events, @_ } );
+    $emitter->emit( 'foo', emitter => $alt_emitter );
+    is scalar @events, 1, 'foo event caught';
+    is refaddr $events[0]->emitter, refaddr $alt_emitter,
+     'alternate emitter correctly specified';
 };
 
 done_testing;


### PR DESCRIPTION
It should be possible for a class to completely encapsulate an `Emitter` object and act like one, e.g.

```
package Node::Emitter {
    use Moo;
    with 'Beam::Emitter';
}

package Node {

    use Moo;
    has _emitter => (
        is        => 'ro',
        init_args => undef,
        default   => sub { Node::Emitter->new },
        handles   => [qw< emit subscribe unsubscribe emit_args >],
    );
}
```
Unfortunately, when `emit()` constructs the `Event` object to be passed to the callback, it hardwires the `Node::Emitter` object in the `emitter` attribute.

This changeset allows the encapsulating class to specify an alternate value for the  `emitter` attribute:
```
package Node::Event {

    use Types::Standard qw(:all);
    use Moo;

    has emitter => (
        is       => 'ro',
        isa      => InstanceOf['Node'],
        required => 1,
    );
}

package Node {

    use Moo;
    has _emitter => (
        is        => 'ro',
        init_args => undef,
        default   => sub { Node::Emitter->new },
        handles   => [qw< emit_args on un subscribe unsubscribe >],
    );

    sub emit {

        my ( $self, $event ) = @_;

        $self->_emitter->emit(
            $event,
            class   => 'Node::Event',
            emitter => $self,
            @_
        );
    }
}

```
so that callbacks will get a reference to the `Node` object, rather than the encapsulated `_emitter` object.
