### PR TITLE
custom listener class may need to be loaded prior to use; do so

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -125,6 +125,7 @@ warnings = 0
 Scalar::Util = 0
 Carp = 0
 Moo = 0
+Module::Runtime = 0
 Types::Standard = 0.008 ; First version with ConsumerOf
 
 [Prereqs / TestRequires]

--- a/dist.ini
+++ b/dist.ini
@@ -132,6 +132,7 @@ Types::Standard = 0.008 ; First version with ConsumerOf
 Test::More = 0
 Test::Fatal = 0
 Test::API = 0
+Test::Lib = 0
 
 [Prereqs / TestRecommends]
 Test::LeakTrace = 0

--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -9,7 +9,7 @@ use Types::Standard qw(:all);
 use Scalar::Util qw( weaken refaddr );
 use Carp qw( croak );
 use Beam::Event;
-use Beam::Listener;
+use Module::Runtime qw( use_module );
 use Moo::Role; # Put this last to ensure proper, automatic cleanup
 
 
@@ -98,7 +98,7 @@ sub subscribe {
 
     my $class = delete $args{ class } || "Beam::Listener";
     croak( "listener object must descend from Beam::Listener" )
-      unless $class->isa( 'Beam::Listener' );
+      unless use_module($class)->isa( 'Beam::Listener' );
 
     my $listener = $class->new( %args, callback => $sub );
 

--- a/t/CustomListener.pm
+++ b/t/CustomListener.pm
@@ -1,0 +1,9 @@
+package t::CustomListener;
+
+use Moo;
+extends 'Beam::Listener';
+
+has attr => ( is => 'ro', required => 1 );
+
+1;
+

--- a/t/lib/CustomListener.pm
+++ b/t/lib/CustomListener.pm
@@ -1,4 +1,4 @@
-package t::CustomListener;
+package CustomListener;
 
 use Moo;
 extends 'Beam::Listener';

--- a/t/listeners.t
+++ b/t/listeners.t
@@ -39,7 +39,6 @@ subtest "Create initial listeners" => sub {
         ok !exception {
             $us11 = $foo->subscribe( evt1 => $s11 );
             $us12 = $foo->subscribe( evt1 => $s12 );
-            $us21 = $foo->subscribe( evt2 => $s21 );
         }, 'construction';
 
     };
@@ -47,16 +46,32 @@ subtest "Create initial listeners" => sub {
     subtest "custom listener class" => sub {
 
         # test constructor is being called with args
-        like exception { $foo->subscribe( evt2 => $s22, class => 'Goo' ) },
+        like exception { $foo->subscribe( evt2 => $s21, class => 'Goo' ) },
         qr/missing required arguments/i, "required attribute missing";
 
         ok !exception {
-            $us22
-              = $foo->subscribe( evt2 => $s22, class => 'Goo', attr => 's22' )
+            $us21
+              = $foo->subscribe( evt2 => $s21, class => 'Goo', attr => 's22' )
         },
         "required attribute specified";
 
     };
+
+    subtest "custom listener class in separate file" => sub {
+
+        # test constructor is being called with args
+        like exception { $foo->subscribe( evt2 => $s22, class => 't::CustomListener' ) },
+        qr/missing required arguments/i, "required attribute missing";
+
+        ok !exception {
+            $us22
+              = $foo->subscribe( evt2 => $s22, class => 't::CustomListener', attr => 's22' )
+        },
+        "required attribute specified";
+
+    };
+
+
 
 };
 
@@ -95,7 +110,7 @@ subtest "Ensure lists are consistent after unsubscription" => sub {
         my @l = sort byref $foo->listeners( 'evt2' );
         my @cb = map { $_->callback } @l;
         is_deeply( \@cb, [$s22], 'remaining listeners consistent' );
-        ok( $l[0]->isa( 'Goo' ), 'listener is in custom Listener class' );
+        ok( $l[0]->isa( 't::CustomListener' ), 'listener is in custom Listener class' );
       }
 };
 

--- a/t/listeners.t
+++ b/t/listeners.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Fatal;
+use Test::Lib;
 
 use Scalar::Util qw[ refaddr ];
 
@@ -60,12 +61,12 @@ subtest "Create initial listeners" => sub {
     subtest "custom listener class in separate file" => sub {
 
         # test constructor is being called with args
-        like exception { $foo->subscribe( evt2 => $s22, class => 't::CustomListener' ) },
+        like exception { $foo->subscribe( evt2 => $s22, class => 'CustomListener' ) },
         qr/missing required arguments/i, "required attribute missing";
 
         ok !exception {
             $us22
-              = $foo->subscribe( evt2 => $s22, class => 't::CustomListener', attr => 's22' )
+              = $foo->subscribe( evt2 => $s22, class => 'CustomListener', attr => 's22' )
         },
         "required attribute specified";
 
@@ -110,7 +111,7 @@ subtest "Ensure lists are consistent after unsubscription" => sub {
         my @l = sort byref $foo->listeners( 'evt2' );
         my @cb = map { $_->callback } @l;
         is_deeply( \@cb, [$s22], 'remaining listeners consistent' );
-        ok( $l[0]->isa( 't::CustomListener' ), 'listener is in custom Listener class' );
+        ok( $l[0]->isa( 'CustomListener' ), 'listener is in custom Listener class' );
       }
 };
 


### PR DESCRIPTION
`subscribe()` made the assumption that the listener class's code had been loaded and invoked methods on it (`isa()`, `new()`).  For the caller, it's more intuitive if `subscribe()` loaded the class's code; otherwise if the caller doesn't load the class, subscribe will emit a

> listener object must descend from Beam::Listener

error message, which leaves the developer irate, as their code is undoubtedly properly subclassing `Beam::Listener`.