### PR TITLE
the logic to determine if emitter was passed was sensitive to an over…

### DIFF
--- a/lib/Beam/Emitter.pm
+++ b/lib/Beam/Emitter.pm
@@ -169,7 +169,7 @@ sub emit {
     return unless exists $self->_listeners->{$name};
 
     my $class = delete $args{ class } || "Beam::Event";
-    $args{ emitter  } ||= $self;
+    $args{ emitter  } = $self if ! defined $args{ emitter };
     $args{ name     } ||= $name;
     my $event = $class->new( %args );
 

--- a/t/emitter.t
+++ b/t/emitter.t
@@ -160,4 +160,27 @@ subtest 'alternate emitter' => sub {
      'alternate emitter correctly specified';
 };
 
+{
+  package My::Overloaded::Emitter;
+  use Moo;
+
+  extends 'My::Emitter';
+  use overload bool => sub { 0 };
+}
+
+subtest 'overloaded bool operator in emitter' => sub {
+
+    my $emitter = My::Emitter->new;
+    my $class;
+
+    $emitter->on( 'foo', sub { $class = ref $_[0]->emitter } );
+    $emitter->emit(
+        'foo',
+        emitter => My::Overloaded::Emitter->new,
+	);
+
+    is( $class, 'My::Overloaded::Emitter', 'insensitive to bool operator' );
+
+};
+
 done_testing;


### PR DESCRIPTION
…loaded bool operator

This code

 ` $args{emitter} ||= $self;
`

is meant to detect if the `%args `array contains the key 'emitter' and assign
`$self` to it if doesn't.  However, if `$args{emitter}` contains an object
which overloads the `bool `operator, it doesn't do that.  It is then
equivalent to

  `$args{emitter} = $self if bool $args{emitter};`

which is definitely not the same thing.  The check should be more properly
written as

  `$args{emitter} = $self if ! defined $args{emitter};`